### PR TITLE
Clock styling: initial fade, responsiveness

### DIFF
--- a/src/clock.html
+++ b/src/clock.html
@@ -23,9 +23,35 @@
     </div>
     <div class="w3-row" id="canvas-wrapper">
       <div id="canvas-constrain">
-        <div id="canvas-sizer">
-          <canvas id="canvas" width="800" height="800">
-          </canvas>
+        <div id="canvas-border">
+          <div id="canvas-sizer">
+            <canvas id="canvas" width="800" height="800">
+            </canvas>
+            <span class="time-marker">
+            </span>
+            <span class="time-marker">
+            </span>
+            <span class="time-marker">
+            </span>
+            <span class="time-marker">
+            </span>
+            <span class="time-marker">
+            </span>
+            <span class="time-marker">
+            </span>
+            <span class="time-marker">
+            </span>
+            <span class="time-marker">
+            </span>
+            <span class="time-marker">
+            </span>
+            <span class="time-marker">
+            </span>
+            <span class="time-marker">
+            </span>
+            <span class="time-marker">
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/clock.html
+++ b/src/clock.html
@@ -21,9 +21,13 @@
     <div class="w3-row">
       <h1 id= "greeting"></h1>
     </div>
-    <div class="w3-row">
-      <canvas id="canvas" width="800" height="800">
-      </canvas>
+    <div class="w3-row" id="canvas-wrapper">
+      <div id="canvas-constrain">
+        <div id="canvas-sizer">
+          <canvas id="canvas" width="800" height="800">
+          </canvas>
+        </div>
+      </div>
     </div>
 
 

--- a/src/scripts/tabi-clock.js
+++ b/src/scripts/tabi-clock.js
@@ -9,13 +9,16 @@ let radius = canvas.height / 2;
 ctx.translate(radius, radius);
 radius = radius * 0.90
 setInterval(drawClock, 1000);
+let needsFade = true;
 
 function drawClock() {
-  drawFace(ctx, radius);
-  drawNumbers(ctx, radius);
+  ctx.clearRect(radius * -1,radius * -1,canvas.width, canvas.height);
   drawTime(ctx, radius);
 }
 
+/*
+ * Deprecated: draws clock face
+ */
 function drawFace(ctx, radius) {
   var grad;
   ctx.beginPath();
@@ -35,6 +38,9 @@ function drawFace(ctx, radius) {
   ctx.fill();
 }
 
+/*
+ * Deprecated: draws clock numbers
+ */
 function drawNumbers(ctx, radius) {
   var ang;
   var num;
@@ -70,6 +76,10 @@ function drawTime(ctx, radius){
     // second
     second=(second*Math.PI/30);
     drawHand(ctx, second, radius*0.9, radius*0.01);
+    if ( needsFade ) {
+      document.querySelector('#canvas-border').classList.add('show');
+      needsFade = false;
+    }
 }
 
 function drawHand(ctx, pos, length, width) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,15 +4,12 @@ body{
 }
 
 #canvas{
-  animation-name: fadeIn;
-  animation-duration: 3s;
   margin:auto;
   width: 100%;
   height: 100%;
   position: absolute;
   left: 0;
   top: 0;
-  opaicty: 0;
 }
 
 #canvas-wrapper {
@@ -28,13 +25,33 @@ body{
   margin: 0 auto;
 }
 
-#canvas-sizer {
+#canvas-border {
   position: absolute;
   left: 0;
   top: 0;
   width: 100%;
   height: 0;
   padding-bottom: 100%;
+  background: black;
+  opacity: 0;
+  border-radius: 50%;
+  box-sizing: border-box;
+}
+
+#canvas-sizer {
+  position: absolute;
+  left: 10px;
+  top: 10px;
+  width: calc(100% - 20px);
+  height: 0;
+  padding-bottom: calc(100% - 20px);
+  background: white;
+  border-radius: 50%;
+  box-sizing: border-box;
+}
+
+.show {
+  animation: fadeIn 0.6s forwards;
 }
 
 #settings{
@@ -60,6 +77,129 @@ body{
 
 #greetingAudio{
   display: none;
+}
+
+.time-marker {
+  counter-increment: clockTime;
+  position: absolute;
+  left: calc(50% - 0.8rem);
+  top: 5%;
+  width: 1.6rem;
+  height: 45%;
+  text-align: center;
+  transform-origin: center bottom !important;
+  font-family: Lora, serif;
+}
+
+.time-marker > .time-marker {
+  width: 100%;
+  height: 100%;
+}
+
+.time-marker::before {
+  content: counter(clockTime);
+  font-size: 1.6rem;
+  display: inline-block;
+}
+
+.time-marker:nth-of-type(2) {
+  transform: rotate(30deg);
+}
+
+.time-marker:nth-of-type(2)::before {
+  transform: rotate(-30deg);
+}
+
+.time-marker:nth-of-type(3) {
+  transform: rotate(60deg);
+}
+
+.time-marker:nth-of-type(3)::before {
+  transform: rotate(-60deg);
+}
+
+.time-marker:nth-of-type(4) {
+  transform: rotate(90deg);
+}
+
+.time-marker:nth-of-type(4)::before {
+  transform: rotate(-90deg);
+}
+
+.time-marker:nth-of-type(5) {
+  transform: rotate(120deg);
+}
+
+.time-marker:nth-of-type(5)::before {
+  transform: rotate(-120deg);
+}
+
+.time-marker:nth-of-type(6) {
+  transform: rotate(150deg);
+}
+
+.time-marker:nth-of-type(6)::before {
+  transform: rotate(-150deg);
+}
+
+.time-marker:nth-of-type(7) {
+  transform: rotate(180deg);
+}
+
+.time-marker:nth-of-type(7)::before {
+  transform: rotate(-180deg);
+}
+
+.time-marker:nth-of-type(8) {
+  transform: rotate(210deg);
+}
+
+.time-marker:nth-of-type(8)::before {
+  transform: rotate(-210deg);
+}
+
+.time-marker:nth-of-type(9) {
+  transform: rotate(240deg);
+}
+
+.time-marker:nth-of-type(9)::before {
+  transform: rotate(-240deg);
+}
+
+.time-marker:nth-of-type(10) {
+  transform: rotate(270deg);
+}
+
+.time-marker:nth-of-type(10)::before {
+  transform: rotate(-270deg);
+}
+
+.time-marker:nth-of-type(11) {
+  transform: rotate(300deg);
+}
+
+.time-marker:nth-of-type(11)::before {
+  transform: rotate(-300deg);
+}
+
+.time-marker:nth-of-type(12) {
+  transform: rotate(330deg);
+}
+
+.time-marker:nth-of-type(12)::before {
+  transform: rotate(-330deg);
+}
+
+@media screen and (max-width: 767px) {
+  .time-marker::before {
+    font-size: 1.2rem;
+  }
+}
+
+@media screen and (max-height: 439px) {
+  .time-marker::before {
+    font-size: 1rem;
+  }
 }
 
 @keyframes fadeIn {

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,8 +7,34 @@ body{
   animation-name: fadeIn;
   animation-duration: 3s;
   margin:auto;
-  width: 80vh;
-  height: 80vh;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  opaicty: 0;
+}
+
+#canvas-wrapper {
+  max-width: 800px;
+  width: 80vw;
+  position: relative;
+  margin: 0 auto;
+}
+
+#canvas-constrain {
+  position: relative;
+  max-width: calc(100vh - 67.5px - 10vh - 10vh);
+  margin: 0 auto;
+}
+
+#canvas-sizer {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 0;
+  padding-bottom: 100%;
 }
 
 #settings{


### PR DESCRIPTION
I added a few containers to the canvas clock to responsively size the clock for all screens. I also shifted the existing CSS animation that was fading the clock in to be triggered by Javascript so that the clock only fades in once it starts drawing -- this way there is something to show. (Before, the fade was starting before the clock was being drawn, causing the abrupt cut). I moved the clock face and numbers from canvas drawing to live HTML/CSS elements, because these render a lot faster than drawing them with canvas every frame, and were tripping up the initial fade as well because they took so long to render on first load.