### PR TITLE
added hoverable dropdown menu, no event listeners

### DIFF
--- a/src/clock.html
+++ b/src/clock.html
@@ -11,7 +11,19 @@
   </head>
 
   <body>
-    <i id= "settings" class="fas fa-cog"></i>
+    
+    
+    <div class="dropdown">
+        <i id= "settings" class="fas fa-cog"></i>
+        <div class="dropdown-content">
+          <button id='bgSetting'>Change Background</button>
+          <button id='tzSetting'>Change Timezone</button>
+        </div>
+    </div>
+  
+
+
+
 
     <audio id= "greetingAudio" controls>
      <source src="" type="audio/mpeg">

--- a/src/styles.css
+++ b/src/styles.css
@@ -18,6 +18,34 @@ body{
   font-size: 2em;
 }
 
+.dropdown {
+  position: fixed;
+  top: 70px;
+  right: 220px;
+  display: inline-block;
+}
+
+.dropdown-content {
+  display: none;
+  position: absolute;
+  background-color: #f1f1f1;
+  min-width: 160px;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  z-index: 1;
+}
+
+.dropdown-content button {
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+}
+
+.dropdown-content button:hover {background-color: #ddd;}
+
+.dropdown:hover .dropdown-content {display: block;}
+
+
 #greeting{
   -o-animation-name: fadeIn;
   -o-animation-duration: 3s;


### PR DESCRIPTION
I've created a menu with sample buttons that can be used to implement real settings changes. There are no event listeners to handle the clicks on these buttons, you should implement them in the tabi-clock.js file once you have an idea of what actions you want to handle.